### PR TITLE
uthash: remove usage of install

### DIFF
--- a/community/uthash/build
+++ b/community/uthash/build
@@ -1,3 +1,4 @@
 #!/bin/sh -e
 
-install -Dm644 src/* -t "$1/usr/include"
+install -d "$1/usr/include"
+install -m644 ./include/*.h "$1/usr/include"


### PR DESCRIPTION
Removing -t would just install all headers into a file called /usr/include so the installed package would be empty. closes #516