### PR TITLE
most: use 4 spaces instead of 8

### DIFF
--- a/community/most/build
+++ b/community/most/build
@@ -1,8 +1,8 @@
 #!/bin/sh -e
 
 ./configure \
-        --prefix=/usr \
-        --sysconfdir=/etc
+    --prefix=/usr \
+    --sysconfdir=/etc
 
 make
 make DESTDIR="$1" install


### PR DESCRIPTION
## Description of package
Here's the pull request to change the spaces to match the style guidelines.

## Installed manifest of package

(`kiss manifest <pkg>`)

```
/var/db/kiss/installed/most/version
/var/db/kiss/installed/most/sources
/var/db/kiss/installed/most/manifest
/var/db/kiss/installed/most/depends
/var/db/kiss/installed/most/checksums
/var/db/kiss/installed/most/build
/var/db/kiss/installed/most/
/var/db/kiss/installed/
/var/db/kiss/
/var/db/
/var/
/usr/share/man/man1/most.1
/usr/share/man/man1/
/usr/share/man/
/usr/share/doc/most/most.txt
/usr/share/doc/most/most.rc
/usr/share/doc/most/most-fun.txt
/usr/share/doc/most/lesskeys.rc
/usr/share/doc/most/changes.txt
/usr/share/doc/most/README
/usr/share/doc/most/
/usr/share/doc/
/usr/share/
/usr/bin/most
/usr/bin/
/usr/
```

## Existing package

- [X] I am the maintainer of this package.
