### PR TITLE
htop: remove python dependency

### DIFF
--- a/community/htop/depends
+++ b/community/htop/depends
@@ -1,3 +1,2 @@
 automake make
 ncurses
-python make


### PR DESCRIPTION
Dependency isn't needed anymore.

Closes #534 

## Existing package

- [x] I am the maintainer of this package.
