### PR TITLE
neovim needs pkgconf

### DIFF
--- a/community/neovim/depends
+++ b/community/neovim/depends
@@ -1,3 +1,4 @@
 automake make
 cmake    make
 libtool  make
+pkgconf  make


### PR DESCRIPTION
The build fails if `pkgconf` is not installed