### PR TITLE
postgresql: remove util-linux make dep

### DIFF
--- a/community/postgresql/build
+++ b/community/postgresql/build
@@ -7,7 +7,6 @@
     --enable-thread-safety \
     --with-libedit-preferred \
     --with-openssl \
-    --with-uuid=e2fs \
     --with-llvm
 
 make world


### PR DESCRIPTION
libuuid was required for the contrib/ programs which we weren't installing anyway. My stuff seems to work fine without them.