### PR TITLE
swaybg: fix depends

### DIFF
--- a/community/swaybg/depends
+++ b/community/swaybg/depends
@@ -1,6 +1,7 @@
 cairo       
-meson make       
 gdk-pixbuf
+meson make       
+pkgconf make
 samurai make     
 wayland          
-wayland-protocols
+wayland-protocols make


### PR DESCRIPTION
Reordered some packages in depends to match alphabetical order, added the needed pkgconf make dependency and set wayland-protocols as a make dependency.

---

## Installed manifest of package

(`kiss manifest <pkg>`)

```
/var/db/kiss/installed/swaybg/version
/var/db/kiss/installed/swaybg/sources
/var/db/kiss/installed/swaybg/manifest
/var/db/kiss/installed/swaybg/depends
/var/db/kiss/installed/swaybg/checksums
/var/db/kiss/installed/swaybg/build
/var/db/kiss/installed/swaybg/
/var/db/kiss/installed/
/var/db/kiss/
/var/db/
/var/
/usr/bin/swaybg
/usr/bin/
/usr/
```

## Existing package

- [X] I am the maintainer of this package.
