### PR TITLE
libaio: conform with new KISS destdir rules

### DIFF
--- a/community/libaio/build
+++ b/community/libaio/build
@@ -1,4 +1,4 @@
 #!/bin/sh -e
 
 make
-make prefix="$1/usr" install
+make install


### PR DESCRIPTION
## Installed manifest of package

Irrelevant.

## Existing package

- [x] I am the maintainer of this package.