### PR TITLE
libgphoto2: eudev dependency added

### DIFF
--- a/community/libgphoto2/build
+++ b/community/libgphoto2/build
@@ -13,7 +13,7 @@ make DESTDIR="$1" install
 export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$1/usr/lib"
 
 # Create and install udev rules for the user in group 'camera'
-mkdir -p "$1"/usr/lib/udev/rules.d
-mkdir -p "$1"/usr/lib/udev/hwdb.d
-"$1"/usr/lib/libgphoto2/print-camera-list udev-rules version 201 group camera > "$1"/usr/lib/udev/rules.d/40-gphoto.rules
-"$1"/usr/lib/libgphoto2/print-camera-list hwdb > "$1"/usr/lib/udev/hwdb.d/20-gphoto.hwdb
+mkdir -p "$1/usr/lib/udev/rules.d"
+mkdir -p "$1/usr/lib/udev/hwdb.d"
+"$1/usr/lib/libgphoto2/print-camera-list" udev-rules version 201 group camera > "$1/usr/lib/udev/rules.d/40-gphoto.rules"
+"$1/usr/lib/libgphoto2/print-camera-list" hwdb > "$1/usr/lib/udev/hwdb.d/20-gphoto.hwdb"

--- a/community/libgphoto2/depends
+++ b/community/libgphoto2/depends
@@ -1,2 +1,3 @@
+eudev
 libtool
 pkgconf make


### PR DESCRIPTION
Eudev is necessary, otherwise the user can't use `gphoto2` to access his camera. 

Another  change has to be done in the build file. For example:

    "$1"/usr/lib/libgphoto2/print-camera-list

should be changed to

    "$1/usr/lib/libgphoto2/print-camera-list"

I can create another commit for the same PR or a second PR. What is your preference ? 

## Existing package

- [x] I am the maintainer of this package.
