### PR TITLE
nnn: silence some build warnings from fts

### DIFF
--- a/community/nnn/build
+++ b/community/nnn/build
@@ -1,7 +1,11 @@
 #!/bin/sh -e
 
 patch -p1 < fts.patch
-touch fts/config.h # workaround for fts build
+cat <<EOF > fts/config.h
+#define HAVE_DECL_MAX 1
+#define HAVE_DECL_UINTMAX_MAX 0
+#define HAVE_DIRFD 1
+EOF
 
 make O_NORL=1 strip
 make DESTDIR="$1" PREFIX=/usr install


### PR DESCRIPTION
The rest are code problems that the author was aware of buit chose not to
deal with.

Don't bump version because this doesn't make any changes to build products.

---

## Description of package

Terminal file manager'

## Installed manifest of package

(`kiss manifest <pkg>`)

`<<No Changes>>`

## New package

- [ ] Latest upstream version.
- [ ] I agree to maintain this package.
- [ ] I agree to notify the @kiss-community maintainers if I can no longer maintain this package.

## Existing package

- [X] I am the maintainer of this package.
