### PR TITLE
tinyramfs-git: explicit PREFIX

### DIFF
--- a/community/tinyramfs-git/build
+++ b/community/tinyramfs-git/build
@@ -1,3 +1,6 @@
 #!/bin/sh -e
 
-make DESTDIR="$1" install
+make \
+    PREFIX=/usr \
+    DESTDIR="$1" \
+    install


### PR DESCRIPTION
## Installed manifest of package

```
/var/db/kiss/installed/tinyramfs-git/version
/var/db/kiss/installed/tinyramfs-git/sources
/var/db/kiss/installed/tinyramfs-git/manifest
/var/db/kiss/installed/tinyramfs-git/build
/var/db/kiss/installed/tinyramfs-git/
/var/db/kiss/installed/
/var/db/kiss/
/var/db/
/var/
/usr/lib/tinyramfs/init.sh
/usr/lib/tinyramfs/hook.d/zfs/zfs.init
/usr/lib/tinyramfs/hook.d/zfs/zfs
/usr/lib/tinyramfs/hook.d/zfs/
/usr/lib/tinyramfs/hook.d/systemd-udev/systemd-udev.init.late
/usr/lib/tinyramfs/hook.d/systemd-udev/systemd-udev.init
/usr/lib/tinyramfs/hook.d/systemd-udev/systemd-udev
/usr/lib/tinyramfs/hook.d/systemd-udev/
/usr/lib/tinyramfs/hook.d/proc/proc.init.late
/usr/lib/tinyramfs/hook.d/proc/proc.init
/usr/lib/tinyramfs/hook.d/proc/proc
/usr/lib/tinyramfs/hook.d/proc/
/usr/lib/tinyramfs/hook.d/mdevd/mdevd.init.late
/usr/lib/tinyramfs/hook.d/mdevd/mdevd.init
/usr/lib/tinyramfs/hook.d/mdevd/mdevd
/usr/lib/tinyramfs/hook.d/mdevd/
/usr/lib/tinyramfs/hook.d/mdev/mdev.init.late
/usr/lib/tinyramfs/hook.d/mdev/mdev.init
/usr/lib/tinyramfs/hook.d/mdev/mdev
/usr/lib/tinyramfs/hook.d/mdev/
/usr/lib/tinyramfs/hook.d/lvm/lvm.init
/usr/lib/tinyramfs/hook.d/lvm/lvm
/usr/lib/tinyramfs/hook.d/lvm/
/usr/lib/tinyramfs/hook.d/luks/luks.init
/usr/lib/tinyramfs/hook.d/luks/luks
/usr/lib/tinyramfs/hook.d/luks/
/usr/lib/tinyramfs/hook.d/keymap/keymap.init
/usr/lib/tinyramfs/hook.d/keymap/keymap
/usr/lib/tinyramfs/hook.d/keymap/
/usr/lib/tinyramfs/hook.d/eudev/eudev.init.late
/usr/lib/tinyramfs/hook.d/eudev/eudev.init
/usr/lib/tinyramfs/hook.d/eudev/eudev
/usr/lib/tinyramfs/hook.d/eudev/
/usr/lib/tinyramfs/hook.d/
/usr/lib/tinyramfs/helper.sh
/usr/lib/tinyramfs/common.sh
/usr/lib/tinyramfs/
/usr/lib/
/usr/bin/tinyramfs
/usr/bin/
/usr/
```

## Existing package

- [ ] I am the maintainer of this package.
