### PR TITLE
oksh: don't explicitly disable curses

### DIFF
--- a/community/oksh/build
+++ b/community/oksh/build
@@ -2,7 +2,6 @@
 
 ./configure \
     --prefix=/usr \
-    --disable-curses \
     --enable-ksh \
     --enable-static
 


### PR DESCRIPTION
Resolves #1074 

## Installed manifest of package

```
/var/db/kiss/installed/oksh/version
/var/db/kiss/installed/oksh/sources
/var/db/kiss/installed/oksh/manifest
/var/db/kiss/installed/oksh/depends
/var/db/kiss/installed/oksh/checksums
/var/db/kiss/installed/oksh/build
/var/db/kiss/installed/oksh/
/var/db/kiss/installed/
/var/db/kiss/
/var/db/
/var/
/usr/share/man/man1/ksh.1
/usr/share/man/man1/
/usr/share/man/
/usr/share/
/usr/bin/ksh
/usr/bin/
/usr/
```

## Existing package

- [x] I am the maintainer of this package.
